### PR TITLE
Flush stdout after each message

### DIFF
--- a/src/bin/ais-compress.rs
+++ b/src/bin/ais-compress.rs
@@ -41,6 +41,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ais_compact::proto::spec::Message::from(line.to_owned())
         };
 
+        // FIXME: https://github.com/stepancheg/rust-protobuf/issues/541
+        //        https://github.com/JaimeValdemoros/ais-compact/pull/5
+        // Once we can flush the underlying writer, we should go back to having
+        // single CodedOutputStream instead of recreating it per loop
         let mut writer = protobuf::CodedOutputStream::new(&mut stdout);
         message.write_length_delimited_to(&mut writer)?;
         writer.flush()?;

--- a/src/bin/ais-compress.rs
+++ b/src/bin/ais-compress.rs
@@ -1,11 +1,10 @@
-use std::io::BufRead;
+use std::io::{BufRead, Write};
 
 use protobuf::{CodedInputStream, Message};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();
-    let mut writer = protobuf::CodedOutputStream::new(&mut stdout);
 
     // Buffers to be reused across loops
     let mut line = String::new();
@@ -42,7 +41,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ais_compact::proto::spec::Message::from(line.to_owned())
         };
 
+        let mut writer = protobuf::CodedOutputStream::new(&mut stdout);
         message.write_length_delimited_to(&mut writer)?;
+        writer.flush()?;
+        drop(writer);
+        stdout.flush()?
     }
     Ok(())
 }


### PR DESCRIPTION
`CodedOutputStream` has a default buffer of 8KB, and stdout is additionally line-buffered.

Flushing `CodedOutputStream` doesn't flush the underlying writer (https://github.com/stepancheg/rust-protobuf/issues/541), so we need to flush it ourselves for now.